### PR TITLE
Correctly generate fields for optional accounts

### DIFF
--- a/crates/anchor-idl/src/account.rs
+++ b/crates/anchor-idl/src/account.rs
@@ -19,11 +19,21 @@ pub fn generate_account_fields(
                 } else {
                     quote! {}
                 };
-                let ty = if info.is_signer {
-                    quote! { Signer<'info> }
+
+                let ty = if let Some(true) = info.is_optional {
+                    if info.is_signer {
+                        quote! { Option<Signer<'info>>}
+                    } else {
+                        quote! { Option<AccountInfo<'info>> }
+                    }
                 } else {
-                    quote! { AccountInfo<'info> }
+                    if info.is_signer {
+                        quote! { Signer<'info> }
+                    } else {
+                        quote! { AccountInfo<'info> }
+                    }
                 };
+       
                 quote! {
                    #annotation
                    pub #acc_name: #ty

--- a/crates/anchor-idl/src/typedef.rs
+++ b/crates/anchor-idl/src/typedef.rs
@@ -168,7 +168,7 @@ pub fn generate_default_fields(fields: &[IdlField]) -> TokenStream {
 pub fn generate_enum_fields(fields: EnumFields) -> TokenStream {
     match fields {
         EnumFields::Named(named_fields) => generate_private_fields(&named_fields),
-        EnumFields::Tuple(tuple_fields) => {
+        EnumFields::Tuple(_tuple_fields) => {
             // TODO
             quote! {}
         }


### PR DESCRIPTION
Makes anchor-gen correctly generate the interface required to call an instruction with optional accounts